### PR TITLE
DOI citeproc URL: always overwrite URL

### DIFF
--- a/manubot/metadata.py
+++ b/manubot/metadata.py
@@ -41,12 +41,7 @@ def get_doi_citeproc(doi):
         logging.error(f'Error fetching metadata for doi:{doi}.\n'
                       f'Invalid response from {response.url}:\n{response.text}')
         raise error
-    # Upgrade to preferred formatting in DOI resolution URLs
-    if 'URL' in citeproc:
-        pattern = re.compile(r'^(https?://d?x?\.?)doi\.org/')
-        citeproc['URL'] = pattern.sub('https://doi.org/', citeproc['URL'])
-    else:
-        citeproc['URL'] = f'https://doi.org/{doi}'
+    citeproc['URL'] = f'https://doi.org/{doi}'
     short_doi_url = get_short_doi_url(doi)
     if short_doi_url:
         citeproc['short_url'] = short_doi_url


### PR DESCRIPTION
Always set the URL for a DOI using the DOI.

Fixes https://travis-ci.org/greenelab/manubot/builds/262063044#L1509-L1520:

```
=================================== FAILURES ===================================
____________________ test_citation_to_citeproc_doi_datacite ____________________
    def test_citation_to_citeproc_doi_datacite():
        citation = 'doi:10.7287/peerj.preprints.3100v1'
        citeproc = citation_to_citeproc(citation)
        assert citeproc['id'] == '11cb5HXoY'
>       assert citeproc['URL'] == 'https://doi.org/10.7287/peerj.preprints.3100v1'
E       AssertionError: assert 'https://peer...rints/3100v1/' == 'https://doi.o...prints.3100v1'
E         - https://peerj.com/preprints/3100v1/
E         + https://doi.org/10.7287/peerj.preprints.3100v1
tests/test_citations.py:66: AssertionError
```