### PR TITLE
Newline at end of JSON files

### DIFF
--- a/manubot/manubot.py
+++ b/manubot/manubot.py
@@ -283,6 +283,7 @@ def prepare_manuscript(args):
     variables['manuscript_stats'] = get_manuscript_stats(text, citation_df)
     with args.variables_path.open('w') as write_file:
         json.dump(variables, write_file, indent=2)
+        write_file.write('\n')
 
     text = template_with_jinja2(text, variables)
 


### PR DESCRIPTION
Related to https://codeyarns.com/2017/02/22/python-json-dump-misses-last-newline/

See also [source code](https://github.com/python/cpython/blob/4388b4257abf3b9c348cf4db8c6144dcc07f3e98/Lib/json/tool.py#L46) of `python -m json.tool`.