### PR TITLE
Fix lookahead in citation string regex

### DIFF
--- a/manubot/manuscript.py
+++ b/manubot/manuscript.py
@@ -41,8 +41,7 @@ def replace_citations_strings_with_ids(text, string_to_id):
     """
     for old, new in string_to_id.items():
         text = re.sub(
-            pattern=re.escape(old) + '(?=[^a-zA-Z0-9/])',
-            #pattern=re.escape(old) + r'(?![\w:.#$%&\-+?<>~/]*[a-zA-Z0-9/])',
+            pattern=re.escape(old) + r'(?![\w:.#$%&\-+?<>~/]*[a-zA-Z0-9/])',
             repl='@' + new,
             string=text,
         )

--- a/manubot/manuscript.py
+++ b/manubot/manuscript.py
@@ -42,6 +42,7 @@ def replace_citations_strings_with_ids(text, string_to_id):
     for old, new in string_to_id.items():
         text = re.sub(
             pattern=re.escape(old) + '(?=[^a-zA-Z0-9/])',
+            #pattern=re.escape(old) + r'(?![\w:.#$%&\-+?<>~/]*[a-zA-Z0-9/])',
             repl='@' + new,
             string=text,
         )

--- a/tests/test_manuscript.py
+++ b/tests/test_manuscript.py
@@ -1,4 +1,7 @@
-from manubot.manuscript import get_citation_strings
+from manubot.manuscript import (
+    get_citation_strings,
+    replace_citations_strings_with_ids
+)
 
 
 def test_get_citation_strings_1():
@@ -18,3 +21,21 @@ def test_get_citation_strings_1():
         '@url:https://www.courtlistener.com/docket/4355308/1/elsevier-inc-v-sci-hub/',
     ])
     assert citations == expected
+
+
+def test_replace_citations_strings_with_ids():
+    """
+    Test that text does not get converted to:
+    
+    > our new Manubot tool [@cTN2TQIL-rootstock; @cTN2TQIL] for automating
+    manuscript generation.
+    
+    See https://github.com/greenelab/manubot/issues/9
+    """
+    string_to_id = {
+        '@url:https://github.com/greenelab/manubot': 'cTN2TQIL',
+        '@url:https://github.com/greenelab/manubot-rootstock': '1B7Y2HVtw',
+    }
+    text = 'our new Manubot tool [@url:https://github.com/greenelab/manubot-rootstock; @url:https://github.com/greenelab/manubot] for automating manuscript generation.'
+    text = replace_citations_strings_with_ids(text, string_to_id)
+    assert '[@1B7Y2HVtw; @cTN2TQIL]' in text


### PR DESCRIPTION
Prevents substrings of longer citation strings from shortcircuiting
the regex match and substitution.

Closes https://github.com/greenelab/manubot/issues/9