### PR TITLE
Improve arXiv published DOI warning

### DIFF
--- a/manubot/arxiv.py
+++ b/manubot/arxiv.py
@@ -80,9 +80,10 @@ def get_arxiv_citeproc(arxiv_id):
     if DOI:
         csl_item['DOI'] = DOI
         journal_ref = entry.findtext(alt_prefix + 'journal_ref')
-        logging.warning(f'arXiv article {arxiv_id} published in'
-                        f'"{journal_ref}" at https://doi.org/{DOI}')
-
+        msg = f'arXiv article {arxiv_id} published at https://doi.org/{DOI}'
+        if journal_ref:
+            msg += f' — {journal_ref}'
+        logging.warning(msg)
     # Set CSL type to report for preprint
     csl_item['type'] = 'report'
     return csl_item


### PR DESCRIPTION
See this [Deep Review build](https://travis-ci.org/greenelab/deep-review/builds/297004423#L1423) where several arXiv preprints have DOI info (published in journal):

```
## WARNING
arXiv article 1503.01919 published in"Algorithms for Computational Biology 9199 (2015) 68" at https://doi.org/10.1007/978-3-319-21233-3_6
## WARNING
arXiv article 1603.09195 published in"PLoS ONE 12(6): e0178751" at https://doi.org/10.1371/journal.pone.0178751
## WARNING
arXiv article 1607.00133 published in"None" at https://doi.org/10.1145/2976749.2978318
## WARNING
arXiv article 1609.02374 published in"None" at https://doi.org/10.1007/s11548-017-1567-8
## WARNING
arXiv article 1610.04181 published in"None" at https://doi.org/10.1093/bioinformatics/btx196
## WARNING
arXiv article 1702.05747 published in"None" at https://doi.org/10.1016/j.media.2017.07.005
```

Several have a DOI but are missing `journal_ref`. Also note the missing space. This PR intends to change the format to be like:

```
## WARNING
arXiv article 1603.09195 published at https://doi.org/10.1371/journal.pone.0178751 — PLoS ONE 12(6): e0178751
## WARNING
arXiv article 1607.00133 published at https://doi.org/10.1145/2976749.2978318
```