### PR TITLE
Author affiliation numbering

### DIFF
--- a/manubot/manubot.py
+++ b/manubot/manubot.py
@@ -387,6 +387,10 @@ def main():
     # See https://stackoverflow.com/a/45446664/4651668
     error_handler = errorhandler.ErrorHandler()
 
+    # Log DeprecationWarnings
+    warnings.simplefilter('always', DeprecationWarning)
+    logging.captureWarnings(True)
+
     # Log to stderr
     logger = logging.getLogger()
     stream_handler = logging.StreamHandler(stream=sys.stderr)

--- a/manubot/manubot.py
+++ b/manubot/manubot.py
@@ -193,8 +193,8 @@ def add_author_affiliations(variables):
     for author in variables['authors']:
         name = author['name']
         affiliations = author.get('affiliations', [])
-        affiliations = (affiliations if isinstance(affiliations, list) else
-                        affiliations.split('; '))
+        if not isinstance(affiliations, list):
+            affiliations = affiliations.split('; ')
         for affiliation in affiliations:
             rows.append((name, affiliation))
     if not rows:

--- a/manubot/manubot.py
+++ b/manubot/manubot.py
@@ -203,11 +203,10 @@ def add_author_affiliations(variables):
     affiliation_df = affil_map_df[['affiliation']].drop_duplicates()
     affiliation_df['affiliation_number'] = range(1, 1 + len(affiliation_df))
     affil_map_df = affil_map_df.merge(affiliation_df)
-    name_to_numbers = {name: list(df.affiliation_number) for name, df in
+    name_to_numbers = {name: sorted(df.affiliation_number) for name, df in
                        affil_map_df.groupby('name')}
     for author in variables['authors']:
-        numbers = name_to_numbers.get(author['name'], [])
-        author['affiliation_numbers'] = numbers
+        author['affiliation_numbers'] = name_to_numbers.get(author['name'], [])
     variables['affiliations'] = affiliation_df.to_dict(orient='records')
     return variables
 

--- a/manubot/manubot.py
+++ b/manubot/manubot.py
@@ -191,12 +191,12 @@ def add_author_affiliations(variables):
     """
     rows = list()
     for author in variables['authors']:
-        name = author['name']
-        affiliations = author.get('affiliations', [])
-        if not isinstance(affiliations, list):
-            affiliations = affiliations.split('; ')
-        for affiliation in affiliations:
-            rows.append((name, affiliation))
+        if 'affiliations' not in author:
+            continue
+        if not isinstance(author['affiliations'], list):
+            author['affiliations'] = author['affiliations'].split('; ')
+        for affiliation in author['affiliations']:
+            rows.append((author['name'], affiliation))
     if not rows:
         return variables
     affil_map_df = pandas.DataFrame(rows, columns=['name', 'affiliation'])

--- a/manubot/manubot.py
+++ b/manubot/manubot.py
@@ -7,6 +7,7 @@ import pathlib
 import re
 import sys
 import textwrap
+import warnings
 
 import errorhandler
 import jinja2
@@ -194,6 +195,12 @@ def add_author_affiliations(variables):
         if 'affiliations' not in author:
             continue
         if not isinstance(author['affiliations'], list):
+            warnings.warn(
+                f"Expected list for {author['name']}'s affiliations. "
+                f"Assuming multiple affiliations are `; ` separated. "
+                f"Please switch affiliations to a list.",
+                category=DeprecationWarning
+            )
             author['affiliations'] = author['affiliations'].split('; ')
         for affiliation in author['affiliations']:
             rows.append((author['name'], affiliation))

--- a/tests/manuscripts/example/content/01.front-matter.md
+++ b/tests/manuscripts/example/content/01.front-matter.md
@@ -24,7 +24,7 @@ on {{date}}.
   {%- endif %}<br>
   <small>
   {%- if author.affiliations is defined %}
-     {{author.affiliations}}
+     {{author.affiliations | join('; ')}}
   {%- endif %}
   {%- if author.funders is defined %}
      · Funded by {{author.funders}}

--- a/tests/manuscripts/example/content/metadata.yaml
+++ b/tests/manuscripts/example/content/metadata.yaml
@@ -11,7 +11,6 @@ author_info:
     twitter: dhimmel
     affiliations:
       - Department of Systems Pharmacology and Translational Therapeutics, University of Pennsylvania
-      - Department of Biological & Medical Informatics, University of California, San Francisco
     funders: GBMF4552
   -
     github: agitter
@@ -20,5 +19,6 @@ author_info:
     orcid: 0000-0002-5324-9833
     twitter: anthonygitter
     affiliations:
-      - Department of Biostatistics and Medical Informatics, University of Wisconsin-Madison and Morgridge Institute for Research
+      - Department of Biostatistics and Medical Informatics, University of Wisconsin-Madison
+      - Morgridge Institute for Research
     funders: NIH U54AI117924

--- a/tests/manuscripts/example/content/metadata.yaml
+++ b/tests/manuscripts/example/content/metadata.yaml
@@ -9,7 +9,9 @@ author_info:
     initials: DSH
     orcid: 0000-0002-3012-7446
     twitter: dhimmel
-    affiliations: Department of Systems Pharmacology and Translational Therapeutics, University of Pennsylvania
+    affiliations:
+      - Department of Systems Pharmacology and Translational Therapeutics, University of Pennsylvania
+      - Department of Biological & Medical Informatics, University of California, San Francisco
     funders: GBMF4552
   -
     github: agitter
@@ -17,5 +19,6 @@ author_info:
     initials: AG
     orcid: 0000-0002-5324-9833
     twitter: anthonygitter
-    affiliations: Department of Biostatistics and Medical Informatics, University of Wisconsin-Madison and Morgridge Institute for Research
+    affiliations:
+      - Department of Biostatistics and Medical Informatics, University of Wisconsin-Madison and Morgridge Institute for Research
     funders: NIH U54AI117924

--- a/tests/test_citations.py
+++ b/tests/test_citations.py
@@ -59,6 +59,7 @@ def test_standardize_citation(citation, expected):
     assert output == expected
 
 
+@pytest.mark.xfail(reason='https://twitter.com/dhimmel/status/950443969313419264')
 def test_citation_to_citeproc_doi_datacite():
     citation = 'doi:10.7287/peerj.preprints.3100v1'
     citeproc = citation_to_citeproc(citation)

--- a/tests/test_manubot.py
+++ b/tests/test_manubot.py
@@ -102,4 +102,4 @@ def test_add_author_affiliations():
     ]
     authors = variables['authors']
     assert authors[0]['affiliation_numbers'] == [1, 2]
-    assert authors[1]['affiliation_numbers'] == [3, 2]
+    assert authors[1]['affiliation_numbers'] == [2, 3]

--- a/tests/test_manubot.py
+++ b/tests/test_manubot.py
@@ -3,7 +3,10 @@ import subprocess
 
 import pytest
 
-from manubot.manubot import read_jsons
+from manubot.manubot import (
+    add_author_affiliations,
+    read_jsons,
+)
 
 directory = pathlib.Path(__file__).parent.resolve()
 
@@ -67,3 +70,36 @@ def test_read_jsons():
     assert 'violet' in user_variables['namespace_1']['rainbow']
     assert 'yellow' in user_variables['namespace_2']['rainbow']
     assert 'orange' in user_variables['namespace_3']['rainbow']
+
+
+def test_add_author_affiliations_empty():
+    variables = {}
+    variables['authors'] = [
+        {'name': 'Jane Roe'},
+        {'name': 'John Doe'},
+    ]
+    returned_variables = add_author_affiliations(variables)
+    assert variables is returned_variables
+    assert 'affiliations' not in variables
+    for author in variables['authors']:
+        assert 'affiliation_numbers' not in author
+
+
+def test_add_author_affiliations():
+    variables = {}
+    variables['authors'] = [
+        # Legacy affiliations format (as a string that's `: ` separated)
+        {'name': 'Jane Roe', 'affiliations': 'Department of Doe, University of Roe; Peppertea University'},
+        # Prefered affiliations format as a list
+        {'name': 'John Doe', 'affiliations': ['Unique University', 'Peppertea University']},
+    ]
+    returned_variables = add_author_affiliations(variables)
+    assert variables is returned_variables
+    assert variables['affiliations'] == [
+        {'affiliation': 'Department of Doe, University of Roe', 'affiliation_number': 1},
+        {'affiliation': 'Peppertea University', 'affiliation_number': 2},
+        {'affiliation': 'Unique University', 'affiliation_number': 3},
+    ]
+    authors = variables['authors']
+    assert authors[0]['affiliation_numbers'] == [1, 2]
+    assert authors[1]['affiliation_numbers'] == [3, 2]

--- a/tests/test_manubot.py
+++ b/tests/test_manubot.py
@@ -88,12 +88,13 @@ def test_add_author_affiliations_empty():
 def test_add_author_affiliations():
     variables = {}
     variables['authors'] = [
-        # Legacy affiliations format (as a string that's `: ` separated)
+        # Deprecated affiliations format (as a string that's `; ` separated)
         {'name': 'Jane Roe', 'affiliations': 'Department of Doe, University of Roe; Peppertea University'},
         # Prefered affiliations format as a list
         {'name': 'John Doe', 'affiliations': ['Unique University', 'Peppertea University']},
     ]
-    returned_variables = add_author_affiliations(variables)
+    with pytest.warns(DeprecationWarning):
+        returned_variables = add_author_affiliations(variables)
     assert variables is returned_variables
     assert variables['affiliations'] == [
         {'affiliation': 'Department of Doe, University of Roe', 'affiliation_number': 1},

--- a/tests/test_manubot.py
+++ b/tests/test_manubot.py
@@ -101,5 +101,9 @@ def test_add_author_affiliations():
         {'affiliation': 'Unique University', 'affiliation_number': 3},
     ]
     authors = variables['authors']
+    assert authors[0]['affiliations'] == [
+        'Department of Doe, University of Roe',
+        'Peppertea University',
+    ]
     assert authors[0]['affiliation_numbers'] == [1, 2]
     assert authors[1]['affiliation_numbers'] == [2, 3]


### PR DESCRIPTION
Generate author affiliation numbering using Manubot. These are exposed as part of the template variables, so that manuscripts can use them. This will assist with alternative frontmatter styles, like the format desired by the Deep Review, see https://github.com/greenelab/deep-review/issues/700.
 

Todos:

- [x] Standardize affiliations format in variables