### PR TITLE
PubMed ID citation support

### DIFF
--- a/manubot/metadata.py
+++ b/manubot/metadata.py
@@ -6,7 +6,7 @@ import urllib.request
 import requests
 
 from manubot.arxiv import get_arxiv_citeproc
-
+from manubot.pubmed import get_pubmed_citeproc
 
 def get_short_doi_url(doi):
     """
@@ -128,6 +128,7 @@ def get_url_citeproc(url):
 
 citeproc_retrievers = {
     'doi': get_doi_citeproc,
+    'pmid': get_pubmed_citeproc,
     'pmcid': get_pmc_citeproc,
     'arxiv': get_arxiv_citeproc,
     'url': get_url_citeproc,

--- a/manubot/metadata.py
+++ b/manubot/metadata.py
@@ -48,27 +48,29 @@ def get_doi_citeproc(doi):
     return citeproc
 
 
-def get_pubmed_citeproc(pubmed_id):
+def get_pmc_citeproc(identifier):
     """
-    Get the citeproc JSON for a PubMed or PubMed Central identifier
+    Get the citeproc JSON for a PubMed Central record by its PMID, PMCID, or
+    DOI, using the NCBI Citation Exporter API.
 
     https://github.com/ncbi/citation-exporter
     https://www.ncbi.nlm.nih.gov/pmc/tools/ctxp/
     https://www.ncbi.nlm.nih.gov/pmc/utils/ctxp/samples
+    https://github.com/greenelab/manubot/issues/21
     """
     params = {
-        'ids': pubmed_id,
-        'report': 'citeproc'
+        'ids': identifier,
+        'report': 'citeproc',
     }
     url = 'https://www.ncbi.nlm.nih.gov/pmc/utils/ctxp'
     response = requests.get(url, params)
     try:
         citeproc = response.json()
     except Exception as error:
-        logging.error(f'Error fetching metadata for pmid:{pubmed_id}.\n'
+        logging.error(f'Error fetching PMC metadata for {identifier}.\n'
                       f'Invalid response from {response.url}:\n{response.text}')
         raise error
-    citeproc['URL'] = f'https://www.ncbi.nlm.nih.gov/pubmed/{pubmed_id}'
+    citeproc['URL'] = f"https://www.ncbi.nlm.nih.gov/pmc/articles/{citeproc['PMCID']}/"
     return citeproc
 
 
@@ -126,7 +128,7 @@ def get_url_citeproc(url):
 
 citeproc_retrievers = {
     'doi': get_doi_citeproc,
-    'pmid': get_pubmed_citeproc,
+    'pmcid': get_pmc_citeproc,
     'arxiv': get_arxiv_citeproc,
     'url': get_url_citeproc,
 }

--- a/manubot/metadata.py
+++ b/manubot/metadata.py
@@ -8,6 +8,7 @@ import requests
 from manubot.arxiv import get_arxiv_citeproc
 from manubot.pubmed import get_pubmed_citeproc
 
+
 def get_short_doi_url(doi):
     """
     Get the shortDOI URL for a DOI.

--- a/manubot/pubmed.py
+++ b/manubot/pubmed.py
@@ -65,11 +65,11 @@ def citeproc_from_pubmed_article(article):
 
     issn = article.findtext("MedlineCitation/Article/Journal/ISSN")
     if issn:
-        citeproc['issn'] = issn
+        citeproc['ISSN'] = issn
 
     date_parts = extract_publication_date_parts(article)
     if date_parts:
-        citeproc['issued'] = [date_parts]
+        citeproc['issued'] = {'date-parts': [date_parts]}
 
     authors_csl = list()
     authors = article.findall("MedlineCitation/Article/AuthorList/Author")

--- a/manubot/pubmed.py
+++ b/manubot/pubmed.py
@@ -1,0 +1,150 @@
+import collections
+import logging
+import xml.etree.ElementTree
+
+import requests
+
+
+def get_pubmed_citeproc(pmid):
+    """
+    Query NCBI E-Utilities to create CSL Items for PubMed IDs.
+
+    https://github.com/greenelab/manubot/issues/21
+    https://github.com/ncbi/citation-exporter/issues/3#issuecomment-355313143
+    """
+    pmid = str(pmid)
+    params = {
+        'db': 'pubmed',
+        'id': pmid,
+        'rettype': 'full',
+    }
+    url = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi'
+    response = requests.get(url, params)
+    try:
+        element_tree = xml.etree.ElementTree.fromstring(response.text)
+        element_tree, = element_tree.findall('PubmedArticle')
+    except Exception as error:
+        logging.error(f'Error fetching PubMed metadata for {pmid}.\n'
+                      f'Invalid response from {response.url}:\n{response.text}')
+        raise error
+    citeproc = citeproc_from_pubmed_article(element_tree)
+    return citeproc
+
+
+def citeproc_from_pubmed_article(article):
+    """
+    article is a PubmedArticle xml element tree
+    
+    https://github.com/citation-style-language/schema/blob/master/csl-data.json
+    """
+    citeproc = collections.OrderedDict()
+
+    title = article.findtext("MedlineCitation/Article/ArticleTitle")
+    if title:
+        citeproc['title'] = title
+
+    volume = article.findtext("MedlineCitation/Article/Journal/JournalIssue/Volume")
+    if volume:
+        citeproc['volume'] = volume
+
+    issue = article.findtext("MedlineCitation/Article/Journal/JournalIssue/Issue")
+    if issue:
+        citeproc['issue'] = issue
+
+    page = article.findtext("MedlineCitation/Article/Pagination/MedlinePgn")
+    if page:
+        citeproc['page'] = page
+
+    journal = article.findtext("MedlineCitation/Article/Journal/Title")
+    if journal:
+        citeproc['container-title'] = journal
+
+    journal_short = article.findtext("MedlineCitation/Article/Journal/ISOAbbreviation")
+    if journal_short:
+        citeproc['container-title-short'] = journal_short
+
+    issn = article.findtext("MedlineCitation/Article/Journal/ISSN")
+    if issn:
+        citeproc['issn'] = issn
+
+    date_parts = extract_publication_date_parts(article)
+    if date_parts:
+        citeproc['issued'] = [date_parts]
+
+    authors_csl = list()
+    authors = article.findall("MedlineCitation/Article/AuthorList/Author")
+    for author in authors:
+        author_csl = collections.OrderedDict()
+        given = author.findtext('ForeName')
+        if given:
+            author_csl['given'] = given
+        family = author.findtext('LastName')
+        if family:
+            author_csl['family'] = family
+        authors_csl.append(author_csl)
+    if authors_csl:
+        citeproc['author'] = authors_csl
+
+    for id_type, key in ('pubmed', 'PMID'), ('pmc', 'PMCID'), ('doi', 'DOI'):
+        xpath = f"PubmedData/ArticleIdList/ArticleId[@IdType='{id_type}']"
+        value = article.findtext(xpath)
+        if value:
+            citeproc[key] = value.lower() if key == 'DOI' else value
+
+    abstract = article.findtext("MedlineCitation/Article/Abstract/AbstractText")
+    if abstract:
+        citeproc['abstract'] = abstract
+
+    citeproc['URL'] = f"https://www.ncbi.nlm.nih.gov/pubmed/{citeproc['PMID']}"
+
+    return citeproc
+
+
+month_abbrev_to_int = {
+    'Jan': 1,
+    'Feb': 2,
+    'Mar': 3,
+    'Apr': 4,
+    'May': 5,
+    'Jun': 6,
+    'Jul': 7,
+    'Aug': 8,
+    'Sep': 9,
+    'Oct': 10,
+    'Nov': 11,
+    'Dec': 12,
+}
+
+
+def extract_publication_date_parts(article):
+    date_parts = []
+
+    # Electronic articles
+    date = article.find("MedlineCitation/Article/ArticleDate")
+    if date:
+        for part in 'Year', 'Month', 'Day':
+            part = date.findtext(part)
+            if not part:
+                break
+            date_parts.append(int(part))
+        return date_parts
+
+    # Print articles
+    date = article.find("MedlineCitation/Article/Journal/JournalIssue/PubDate")
+    year = date.findtext('Year')
+    if year:
+        date_parts.append(int(year))
+    month = date.findtext('Month')
+    if month:
+        date_parts.append(month_abbrev_to_int[month])
+    day = date.findtext('Day')
+    if day:
+        date_parts.append(int(day))
+    return date_parts
+
+
+if __name__ == '__main__':
+    for pmid in 25648772, 27094199, 11234041:
+        print(pmid)
+        citeproc = get_pubmed_citeproc(pmid)
+        print(citeproc)

--- a/manubot/pubmed.py
+++ b/manubot/pubmed.py
@@ -96,6 +96,7 @@ def citeproc_from_pubmed_article(article):
         citeproc['abstract'] = abstract
 
     citeproc['URL'] = f"https://www.ncbi.nlm.nih.gov/pubmed/{citeproc['PMID']}"
+    citeproc['type'] = 'article-journal'
 
     return citeproc
 
@@ -144,7 +145,7 @@ def extract_publication_date_parts(article):
 
 
 if __name__ == '__main__':
-    for pmid in 25648772, 27094199, 11234041:
+    for pmid in 25648772, 27094199, 11234041, 14728133:
         print(pmid)
         citeproc = get_pubmed_citeproc(pmid)
         print(citeproc)

--- a/tests/manuscripts/example/content/02.body.md
+++ b/tests/manuscripts/example/content/02.body.md
@@ -8,3 +8,5 @@ The website Sci-Hub, now in its fifth year of existence, provides gratis access 
 Sci-Hub brands itself as "the first pirate website in the world to provide mass and public access to tens of millions of research papers."
 The website, started in 2011, is run by Alexandra Elbakyan, a graduate student and native of Kazakhstan who now resides in Russia [@doi:10.1126/science.aaf5675; @doi:10.1038/nature.2015.18876].
 Elbakyan describes herself as motivated to provide universal access to knowledge [@url:https://engineuring.wordpress.com/2016/03/11/sci-hub-is-a-goal-changing-the-system-is-a-method/; @url:https://www.courtlistener.com/docket/4355308/50/elsevier-inc-v-sci-hub/; @url:http://www.leafscience.org/alexandra-elbakyan/].
+
+Cite the same paper in three ways [@pmid:25648772; @pmcid:PMC4304851; @doi:10.7717/peerj.705].

--- a/tests/test_citations.py
+++ b/tests/test_citations.py
@@ -105,15 +105,44 @@ def test_citation_to_citeproc_pmc(identifier, citation_id):
     assert citeproc['PMCID'] == 'PMC3041534'
 
 
-@pytest.mark.skip
-def test_citation_to_citeproc_pubmed():
+def test_citation_to_citeproc_pubmed_1():
+    """
+    Generated from XML returned by
+    https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&id=21347133&rettype=full
+    """
     citation = 'pmid:21347133'
     citeproc = citation_to_citeproc(citation)
     assert citeproc['id'] == 'y9ONtSZ9'
+    assert citeproc['type'] == 'article-journal'
     assert citeproc['URL'] == 'https://www.ncbi.nlm.nih.gov/pubmed/21347133'
-    assert citeproc['container-title'] == 'Summit on Translational Bioinformatics'
-    assert citeproc['title'] == 'Secondary Use of EHR: Data Quality Issues and Informatics Opportunities'
+    assert citeproc['container-title'] == 'AMIA Joint Summits on Translational Science proceedings. AMIA Joint Summits on Translational Science'
+    assert citeproc['title'] == 'Secondary Use of EHR: Data Quality Issues and Informatics Opportunities.'
+    assert citeproc['issued']['date-parts'] == [[2010, 3, 1]]
     authors = citeproc['author']
+    assert authors[0]['given'] == 'Taxiarchis'
     assert authors[0]['family'] == 'Botsis'
     assert citeproc['PMID'] == '21347133'
     assert citeproc['PMCID'] == 'PMC3041534'
+
+
+def test_citation_to_citeproc_pubmed_2():
+    """
+    Generated from XML returned by
+    https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&id=27094199&rettype=full
+    """
+    citation = 'pmid:27094199'
+    citeproc = citation_to_citeproc(citation)
+    print(citeproc)
+    assert citeproc['id'] == 'alaFV9OY'
+    assert citeproc['type'] == 'article-journal'
+    assert citeproc['URL'] == 'https://www.ncbi.nlm.nih.gov/pubmed/27094199'
+    assert citeproc['container-title'] == 'Circulation. Cardiovascular genetics'
+    assert citeproc['container-title-short'] == 'Circ Cardiovasc Genet'
+    assert citeproc['page'] == '179-84'
+    assert citeproc['title'] == 'Genetic Association-Guided Analysis of Gene Networks for the Study of Complex Traits.'
+    assert citeproc['issued']['date-parts'] == [[2016, 4]]
+    authors = citeproc['author']
+    assert authors[0]['given'] == 'Casey S'
+    assert authors[0]['family'] == 'Greene'
+    assert citeproc['PMID'] == '27094199'
+    assert citeproc['DOI'] == '10.1161/circgenetics.115.001181'

--- a/tests/test_citations.py
+++ b/tests/test_citations.py
@@ -88,6 +88,24 @@ def test_citation_to_citeproc_arxiv():
     assert citeproc['DOI'] == '10.1209/0295-5075/81/68004'
 
 
+@pytest.mark.parametrize('identifier,citation_id', [
+    ('PMC3041534', 'RoOhUFKU'),
+    ('21347133', '4nofiYkF'),
+])
+def test_citation_to_citeproc_pmc(identifier, citation_id):
+    citation = f'pmcid:{identifier}'
+    citeproc = citation_to_citeproc(citation)
+    assert citeproc['id'] == citation_id
+    assert citeproc['URL'] == 'https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3041534/'
+    assert citeproc['container-title'] == 'Summit on Translational Bioinformatics'
+    assert citeproc['title'] == 'Secondary Use of EHR: Data Quality Issues and Informatics Opportunities'
+    authors = citeproc['author']
+    assert authors[0]['family'] == 'Botsis'
+    assert citeproc['PMID'] == '21347133'
+    assert citeproc['PMCID'] == 'PMC3041534'
+
+
+@pytest.mark.skip
 def test_citation_to_citeproc_pubmed():
     citation = 'pmid:21347133'
     citeproc = citation_to_citeproc(citation)

--- a/tests/test_citations.py
+++ b/tests/test_citations.py
@@ -146,3 +146,13 @@ def test_citation_to_citeproc_pubmed_2():
     assert authors[0]['family'] == 'Greene'
     assert citeproc['PMID'] == '27094199'
     assert citeproc['DOI'] == '10.1161/circgenetics.115.001181'
+
+
+def test_citation_to_citeproc_pubmed_book():
+    """
+    Extracting CSL metadata from books in PubMed is not supported.
+    Logic not implemented to parse XML returned by
+    https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&id=29227604&rettype=full
+    """
+    with pytest.raises(NotImplementedError):
+        citation_to_citeproc('pmid:29227604')


### PR DESCRIPTION
This pull request migrates the previous `pmid` citations functionality (from NCBI Citation Exporter) to `pmcid`. This is more accurate because the NCBI Citation Exporter only works for records in PubMed Central. `pmid` citations are now supported that use the NCBI E-Utilities. `pubmed.py` enables parsing the XML returned by from E-Utilities into JSON CSL metadata.

Closes https://github.com/greenelab/manubot/issues/21
Refs https://github.com/ncbi/citation-exporter/issues/3