### PR TITLE
Remove extra space between month and day

### DIFF
--- a/manubot/manubot.py
+++ b/manubot/manubot.py
@@ -240,7 +240,7 @@ def get_metadata_and_variables(args):
     logging.info(f'Using {now:%Z} timezone.\n'
         f'Dating manuscript with the current datetime: {now.isoformat()}')
     metadata['date-meta'] = now.date().isoformat()
-    variables['date'] = f'{now:%B %e, %Y}'
+    variables['date'] = f'{now:%B} {now.day}, {now.year}'
 
     # Process authors metadata
     authors = metadata.pop('author_info', [])


### PR DESCRIPTION
I noticed the following in `variables.json`:

```json
  "date": "January  9, 2018",
```

There are two spaces since 9 gets a space prepended. Does not effect days > 9. See https://stackoverflow.com/questions/904928.

```python
>>> import datetime
>>> now = datetime.datetime(2018, 1, 9, 23, 8, 50, 558715)
>>> f'{now:%B %e, %Y}'  # Problem
'January  9, 2018'
>>> f'{now:%B %-e, %Y}'  # Fix (linux only)
'January 9, 2018'
>>> f'{now:%B} {now.day}, {now.year}'  # Fix (more general)
'January 9, 2018'
```