### PR TITLE
Do not import jsonref & jsonschema unless CSL pruning

### DIFF
--- a/manubot/cite/__init__.py
+++ b/manubot/cite/__init__.py
@@ -5,8 +5,6 @@ import logging
 import re
 import sys
 
-import base62
-
 from manubot.cite.arxiv import get_arxiv_citeproc
 from manubot.cite.doi import get_doi_citeproc
 from manubot.cite.pubmed import (
@@ -91,6 +89,7 @@ def get_citation_id(standard_citation):
     """
     Get the citation_id for a standard_citation.
     """
+    import base62
     assert '@' not in standard_citation
     as_bytes = standard_citation.encode()
     blake_hash = hashlib.blake2b(as_bytes, digest_size=6)

--- a/manubot/cite/citeproc.py
+++ b/manubot/cite/citeproc.py
@@ -2,9 +2,6 @@ import copy
 import functools
 import logging
 
-import jsonref
-import jsonschema
-
 citeproc_type_fixer = {
     'journal-article': 'article-journal',
     'book-chapter': 'chapter',
@@ -51,6 +48,9 @@ def get_jsonschema_csl_validator():
     """
     Return a jsonschema validator for the CSL Item JSON Schema
     """
+    import jsonref
+    import jsonschema
+
     url = 'https://github.com/dhimmel/schema/raw/manubot/csl-data.json'
     # Use jsonref to workaround https://github.com/Julian/jsonschema/issues/447
     schema = jsonref.load_uri(url, jsonschema=True)


### PR DESCRIPTION
Reduces the chance of code failing due to missing these dependencies.