### PR TITLE
Enhanced API calls: set User-Agent header & E-Utility rate limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,24 +1,6 @@
-# Python
+### Python ###
 __pycache__/
 *.egg-info/
 .ipynb_checkpoints
 .cache
 .pytest_cache/
-
-# System specific files
-
-## Linux
-*~
-.Trash-*
-
-## macOS
-.DS_Store
-._*
-.Trashes
-
-## Windows
-Thumbs.db
-[Dd]esktop.ini
-
-## Text Editors
-.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,24 @@
-### Python ###
+# Python
 __pycache__/
 *.egg-info/
 .ipynb_checkpoints
 .cache
 .pytest_cache/
+
+# System specific files
+
+## Linux
+*~
+.Trash-*
+
+## macOS
+.DS_Store
+._*
+.Trashes
+
+## Windows
+Thumbs.db
+[Dd]esktop.ini
+
+## Text Editors
+.vscode

--- a/manubot/cite/arxiv.py
+++ b/manubot/cite/arxiv.py
@@ -5,6 +5,8 @@ import xml.etree.ElementTree
 
 import requests
 
+from manubot.util import get_manubot_user_agent
+
 
 def get_arxiv_citeproc(arxiv_id):
     """
@@ -28,7 +30,10 @@ def get_arxiv_citeproc(arxiv_id):
         'id_list': arxiv_id,
         'max_results': 1,
     }
-    response = requests.get(url, params)
+    headers = {
+        'User-Agent': get_manubot_user_agent(),
+    }
+    response = requests.get(url, params, headers=headers)
 
     # XML namespace prefixes
     prefix = '{http://www.w3.org/2005/Atom}'

--- a/manubot/cite/doi.py
+++ b/manubot/cite/doi.py
@@ -4,6 +4,7 @@ import urllib.request
 import requests
 
 from manubot.cite.pubmed import get_pubmed_ids_for_doi
+from manubot.util import get_manubot_user_agent
 
 
 def get_short_doi_url(doi):
@@ -12,8 +13,11 @@ def get_short_doi_url(doi):
     """
     quoted_doi = urllib.request.quote(doi)
     url = 'http://shortdoi.org/{}?format=json'.format(quoted_doi)
+    headers = {
+        'User-Agent': get_manubot_user_agent(),
+    }
     try:
-        response = requests.get(url).json()
+        response = requests.get(url, headers=headers).json()
         short_doi = response['ShortDOI']
         short_doi = short_doi[3:]  # Remove "10/" prefix
         short_url = 'https://doi.org/' + short_doi
@@ -31,6 +35,7 @@ def get_doi_citeproc(doi):
     url = 'https://doi.org/' + urllib.request.quote(doi)
     header = {
         'Accept': 'application/vnd.citationstyles.csl+json',
+        'User-Agent': get_manubot_user_agent(),
     }
     response = requests.get(url, headers=header)
     try:

--- a/manubot/cite/isbn.py
+++ b/manubot/cite/isbn.py
@@ -32,9 +32,13 @@ def get_isbn_citeproc_citoid(isbn):
     """
     import isbnlib
     import requests
+    from manubot.util import get_manubot_user_agent
+    headers = {
+        'User-Agent': get_manubot_user_agent(),
+    }
     isbn = isbnlib.to_isbn13(isbn)
     url = f'https://en.wikipedia.org/api/rest_v1/data/citation/mediawiki/{isbn}'
-    response = requests.get(url)
+    response = requests.get(url, headers=headers)
     result = response.json()
     if isinstance(result, dict):
         if result['title'] == 'Not found.':

--- a/manubot/cite/pubmed.py
+++ b/manubot/cite/pubmed.py
@@ -245,7 +245,7 @@ def get_pmcid_and_pmid_for_doi(doi):
         return {}
     try:
         element_tree = xml.etree.ElementTree.fromstring(response.text)
-    except Exception as error:
+    except Exception:
         logging.warning(f'Error fetching PMC ID conversion for {doi}.\n'
                         f'Response from {response.url}:\n{response.text}')
         return {}

--- a/manubot/cite/pubmed.py
+++ b/manubot/cite/pubmed.py
@@ -5,6 +5,8 @@ import xml.etree.ElementTree
 
 import requests
 
+from manubot.util import get_manubot_user_agent
+
 
 def get_pmc_citeproc(pmcid):
     """
@@ -305,15 +307,3 @@ def get_pubmed_ids_for_doi(doi):
         if pmid:
             pubmed_ids['PMID'] = pmid
     return pubmed_ids
-
-
-def get_manubot_user_agent():
-    """
-    Return a User-Agent string for web request headers to help services
-    identify requests as coming from Manubot.
-    """
-    try:
-        from manubot import __version__ as manubot_version
-    except ImportError:
-        manubot_version = ''
-    return f'manubot/{manubot_version}'

--- a/manubot/cite/url.py
+++ b/manubot/cite/url.py
@@ -17,14 +17,16 @@ def get_url_citeproc_greycite(url):
     http://knowledgeblog.org/greycite
     https://arxiv.org/abs/1304.7151
     https://git.io/v9N2C
-
-    Uses urllib.request.urlopen rather than requests.get due to
-    https://github.com/kennethreitz/requests/issues/4023
     """
+    from manubot.util import get_manubot_user_agent
+    headers = {
+        'Connection': 'close',  # https://github.com/kennethreitz/requests/issues/4023
+        'User-Agent': get_manubot_user_agent(),
+    }
     response = requests.get(
         'http://greycite.knowledgeblog.org/json',
         params={'uri': url},
-        headers={'Connection': 'close'},
+        headers=headers,
     )
     # Some Greycite responses were valid JSON besides for an error appended
     # like "<p>*** Date set from uri<p>" or "<p>*** fetch error : 404<p>".

--- a/manubot/util.py
+++ b/manubot/util.py
@@ -1,4 +1,6 @@
 import importlib
+import platform
+import sys
 
 # Email address that forwards to Manubot maintainers
 contact_email = 'contact@manubot.org'
@@ -24,4 +26,8 @@ def get_manubot_user_agent():
         from manubot import __version__ as manubot_version
     except ImportError:
         manubot_version = ''
-    return f'manubot/{manubot_version} <{contact_email}>'
+    return (
+        f'manubot/{manubot_version} '
+        f'({platform.system()}; Python/{sys.version_info.major}.{sys.version_info.minor}) '
+        f'<{contact_email}>'
+    )

--- a/manubot/util.py
+++ b/manubot/util.py
@@ -1,5 +1,8 @@
 import importlib
 
+# Email address that forwards to Manubot maintainers
+contact_email = 'contact@manubot.org'
+
 
 def import_function(name):
     """
@@ -10,3 +13,15 @@ def import_function(name):
     module_name, function_name = name.rsplit('.', 1)
     module = importlib.import_module(module_name)
     return getattr(module, function_name)
+
+
+def get_manubot_user_agent():
+    """
+    Return a User-Agent string for web request headers to help services
+    identify requests as coming from Manubot.
+    """
+    try:
+        from manubot import __version__ as manubot_version
+    except ImportError:
+        manubot_version = ''
+    return f'manubot/{manubot_version} <{contact_email}>'

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setuptools.setup(
         'pandas',
         'pybase62',
         'pyyaml',
+        'ratelimiter',
         'requests-cache',
         'requests',
     ],


### PR DESCRIPTION
Adds new manubot contact email to user-agent, which can be helpful so resources can contact us regarding our API requests. Adds platform and python version info to user-agent so the upcoming translation-server can monitor usage.