### PR TITLE
Integration with the translate.manubot.org translation-server

### DIFF
--- a/manubot/cite/isbn.py
+++ b/manubot/cite/isbn.py
@@ -25,17 +25,6 @@ def get_isbn_citeproc(isbn):
     raise Exception(f'all get_isbn_citeproc methods failed for {isbn}')
 
 
-def get_isbn_citeproc_isbnlib(isbn):
-    """
-    Generate CSL JSON Data for an ISBN using isbnlib.
-    """
-    import isbnlib
-    metadata = isbnlib.meta(isbn, cache=None)
-    csl_json = isbnlib.registry.bibformatters['csl'](metadata)
-    csl_data = json.loads(csl_json)
-    return csl_data
-
-
 def get_isbn_citeproc_zotero(isbn):
     """
     Generate CSL JSON Data for an ISBN using Zotero's translation-server.
@@ -83,6 +72,7 @@ def get_isbn_citeproc_citoid(isbn):
         if csl_author:
             csl_data['author'] = csl_author
     if 'date' in mediawiki:
+        year_pattern = re.compile(r'[0-9]{4}')
         match = year_pattern.search(mediawiki['date'])
         if match:
             year = int(match.group())
@@ -111,7 +101,15 @@ def get_isbn_citeproc_citoid(isbn):
     return csl_data
 
 
-year_pattern = re.compile(r'[0-9]{4}')
+def get_isbn_citeproc_isbnlib(isbn):
+    """
+    Generate CSL JSON Data for an ISBN using isbnlib.
+    """
+    import isbnlib
+    metadata = isbnlib.meta(isbn, cache=None)
+    csl_json = isbnlib.registry.bibformatters['csl'](metadata)
+    csl_data = json.loads(csl_json)
+    return csl_data
 
 
 isbn_retrievers = [

--- a/manubot/cite/isbn.py
+++ b/manubot/cite/isbn.py
@@ -6,10 +6,12 @@ import re
 
 def get_isbn_citeproc(isbn):
     """
-    Generate CSL JSON Data for an ISBN.
+    Generate CSL JSON Data for an ISBN. Converts all ISBNs to 13-digit format.
 
-    Currently, uses Citoid to retrieve metadata, although which resource this
-    function delegates to may change in the future.
+    This function uses a list of CSL JSON Item metadata retrievers, specified
+    by the module-level variable `isbn_retrievers`. The methods are attempted
+    in order, with this function returning the metadata from the first
+    non-failing method.
     """
     import isbnlib
     isbn = isbnlib.to_isbn13(isbn)

--- a/manubot/cite/isbn.py
+++ b/manubot/cite/isbn.py
@@ -18,7 +18,7 @@ def get_isbn_citeproc(isbn):
             return retriever(isbn)
         except Exception as error:
             logging.warning(
-                f'Error in {function.__name__} for {isbn} '
+                f'Error in {retriever.__name__} for {isbn} '
                 f'due to a {error.__class__.__name__}:\n{error}'
             )
             logging.info(error, exc_info=True)

--- a/manubot/cite/url.py
+++ b/manubot/cite/url.py
@@ -2,8 +2,6 @@ import json
 import logging
 import re
 
-import requests
-
 
 def get_url_citeproc(url):
     """
@@ -48,6 +46,7 @@ def get_url_citeproc_greycite(url):
     https://arxiv.org/abs/1304.7151
     https://git.io/v9N2C
     """
+    import requests
     from manubot.util import get_manubot_user_agent
     headers = {
         'Connection': 'close',  # https://github.com/kennethreitz/requests/issues/4023

--- a/manubot/cite/url.py
+++ b/manubot/cite/url.py
@@ -9,14 +9,9 @@ def get_url_citeproc(url):
     """
     Get citeproc for a URL trying a sequence of strategies.
     """
-    functions = [
-        get_url_citeproc_zotero,
-        get_url_citeproc_greycite,
-        get_url_citeproc_manual,
-    ]
-    for function in functions:
+    for retriever in url_retrievers:
         try:
-            return function(url)
+            return retriever(url)
         except Exception as error:
             logging.warning(
                 f'Error in {function.__name__} for {url} '
@@ -80,3 +75,10 @@ def get_url_citeproc_manual(url):
         'URL': url,
         'type': 'webpage',
     }
+
+
+url_retrievers = [
+    get_url_citeproc_zotero,
+    get_url_citeproc_greycite,
+    get_url_citeproc_manual,
+]

--- a/manubot/cite/url.py
+++ b/manubot/cite/url.py
@@ -23,6 +23,7 @@ def get_url_citeproc(url):
                 f'due to a {error.__class__.__name__}:\n{error}'
             )
             logging.info(error, exc_info=True)
+    raise Exception(f'all get_url_citeproc methods failed for {url}')
 
 
 def get_url_citeproc_zotero(url):
@@ -33,9 +34,9 @@ def get_url_citeproc_zotero(url):
         export_as_csl,
         web_query,
     )
-    zotero_json = web_query(url)
-    csl_json = export_as_csl(zotero_json)
-    csl_item, = csl_json
+    zotero_data = web_query(url)
+    csl_data = export_as_csl(zotero_data)
+    csl_item, = csl_data
     return csl_item
 
 

--- a/manubot/cite/url.py
+++ b/manubot/cite/url.py
@@ -5,14 +5,38 @@ import re
 import requests
 
 
+def get_url_citeproc(url):
+    """
+    Get citeproc for a URL trying a sequence of strategies.
+    """
+    functions = [
+        get_url_citeproc_zotero,
+        get_url_citeproc_greycite,
+        get_url_citeproc_manual,
+    ]
+    for function in functions:
+        try:
+            return function(url)
+        except Exception as error:
+            logging.warning(
+                f'Error in {function.__name__} for {url} '
+                f'due to a {error.__class__.__name__}:\n{error}'
+            )
+            logging.info(error, exc_info=True)
+
+
 def get_url_citeproc_zotero(url):
+    """
+    Use Zotero's translation-server to generate a CSL Item for the specified URL.
+    """
     from manubot.cite.zotero import (
         export_as_csl,
         web_query,
     )
     zotero_json = web_query(url)
     csl_json = export_as_csl(zotero_json)
-    return csl_json
+    csl_item, = csl_json
+    return csl_item
 
 
 def get_url_citeproc_greycite(url):
@@ -55,23 +79,3 @@ def get_url_citeproc_manual(url):
         'URL': url,
         'type': 'webpage',
     }
-
-
-def get_url_citeproc(url):
-    """
-    Get citeproc for a URL trying a sequence of strategies.
-    """
-    functions = [
-        get_url_citeproc_zotero,
-        get_url_citeproc_greycite,
-        get_url_citeproc_manual,
-    ]
-    for function in functions:
-        try:
-            return function(url)
-        except Exception as error:
-            logging.warning(
-                f'Error in {function.__name__} for {url} '
-                f'due to a {error.__class__.__name__}:\n{error}'
-            )
-            logging.info(error, exc_info=True)

--- a/manubot/cite/url.py
+++ b/manubot/cite/url.py
@@ -6,6 +6,11 @@ import re
 def get_url_citeproc(url):
     """
     Get citeproc for a URL trying a sequence of strategies.
+
+    This function uses a list of CSL JSON Item metadata retrievers, specified
+    by the module-level variable `url_retrievers`. The methods are attempted
+    in order, with this function returning the metadata from the first
+    non-failing method.
     """
     for retriever in url_retrievers:
         try:

--- a/manubot/cite/url.py
+++ b/manubot/cite/url.py
@@ -12,7 +12,7 @@ def get_url_citeproc(url):
             return retriever(url)
         except Exception as error:
             logging.warning(
-                f'Error in {function.__name__} for {url} '
+                f'Error in {retriever.__name__} for {url} '
                 f'due to a {error.__class__.__name__}:\n{error}'
             )
             logging.info(error, exc_info=True)

--- a/manubot/cite/zotero.py
+++ b/manubot/cite/zotero.py
@@ -69,13 +69,3 @@ def export_as_csl(zotero_data):
         logging.warning(f'Error parsing export_as_csl output as JSON:\n{response.text}')
         raise error
     return csl_json
-
-
-if __name__ == '__main__':
-    import json
-    #data = web_query('http://docs.python-requests.org/en/master/user/quickstart/')
-    url = 'https://www.ncbi.nlm.nih.gov/pubmed/?term=crispr'
-    data = web_query(url)
-    print(json.dumps(data, indent=2))
-    csl_json = export_as_csl(data)
-    print(json.dumps(csl_json, indent=2))

--- a/manubot/cite/zotero.py
+++ b/manubot/cite/zotero.py
@@ -1,3 +1,12 @@
+"""
+Methods to interact with a Zotero translation-server.
+https://github.com/zotero/translation-server
+
+The Manubot team currently hosts a public translation server at
+https://translate.manubot.org. More information on this instance at
+https://github.com/greenelab/manubot/issues/82.
+"""
+
 import json
 import logging
 

--- a/manubot/cite/zotero.py
+++ b/manubot/cite/zotero.py
@@ -1,3 +1,6 @@
+import json
+import logging
+
 import requests
 
 from manubot.util import get_manubot_user_agent
@@ -7,7 +10,8 @@ base_url = 'https://translate.manubot.org'
 
 def web_query(url):
     """
-    Return Zotero citation metadata for a URL
+    Return Zotero citation metadata for a URL as a list containing a single element that
+    is a dictionary with the URL's metadata.
     """
     headers = {
         'User-Agent': get_manubot_user_agent(),
@@ -15,7 +19,18 @@ def web_query(url):
     }
     api_url = f'{base_url}/web'
     response = requests.post(api_url, headers=headers, data=str(url))
-    return response.json()
+    try:
+        zotero_data = response.json()
+    except Exception as error:
+        logging.warning(f'Error parsing web_query output as JSON for {url}:\n{response.text}')
+        raise error
+    if response.status_code == 300:
+        logging.warning(
+            f'web_query returned multiple results for {url}:\n' +
+            json.dumps(zotero_data, indent=2)
+        )
+        raise ValueError(f'multiple results for {url}')
+    return zotero_data
 
 
 def search_query(identifier):
@@ -29,7 +44,11 @@ def search_query(identifier):
         'Content-Type': 'text/plain',
     }
     response = requests.post(api_url, headers=headers, data=str(identifier))
-    return response.json()
+    try:
+        return response.json()
+    except Exception as error:
+        logging.warning(f'Error parsing search_query output as JSON for {identifier}:\n{response.text}')
+        raise error
 
 
 def export_as_csl(zotero_data):
@@ -44,12 +63,19 @@ def export_as_csl(zotero_data):
         'User-Agent': get_manubot_user_agent(),
     }
     response = requests.post(api_url, params=params, headers=headers, json=zotero_data)
-    csl_json = response.json()
+    try:
+        csl_json = response.json()
+    except Exception as error:
+        logging.warning(f'Error parsing export_as_csl output as JSON:\n{response.text}')
+        raise error
     return csl_json
+
 
 if __name__ == '__main__':
     import json
-    data = web_query('http://docs.python-requests.org/en/master/user/quickstart/')
+    #data = web_query('http://docs.python-requests.org/en/master/user/quickstart/')
+    url = 'https://www.ncbi.nlm.nih.gov/pubmed/?term=crispr'
+    data = web_query(url)
     print(json.dumps(data, indent=2))
     csl_json = export_as_csl(data)
     print(json.dumps(csl_json, indent=2))

--- a/manubot/cite/zotero.py
+++ b/manubot/cite/zotero.py
@@ -1,0 +1,55 @@
+import requests
+
+from manubot.util import get_manubot_user_agent
+
+base_url = 'https://translate.manubot.org'
+
+
+def web_query(url):
+    """
+    Return Zotero citation metadata for a URL
+    """
+    headers = {
+        'User-Agent': get_manubot_user_agent(),
+        'Content-Type': 'text/plain',
+    }
+    api_url = f'{base_url}/web'
+    response = requests.post(api_url, headers=headers, data=str(url))
+    return response.json()
+
+
+def search_query(identifier):
+    """
+    Supports DOI, ISBN, PMID, arXiv ID.
+    curl -d 10.2307/4486062 -H 'Content-Type: text/plain' http://127.0.0.1:1969/search
+    """
+    api_url = f'{base_url}/search'
+    headers = {
+        'User-Agent': get_manubot_user_agent(),
+        'Content-Type': 'text/plain',
+    }
+    response = requests.post(api_url, headers=headers, data=str(identifier))
+    return response.json()
+
+
+def export_as_csl(zotero_data):
+    """
+    curl -d @items.json -H 'Content-Type: application/json' 'http://127.0.0.1:1969/export?format=bibtex'
+    """
+    api_url = f'{base_url}/export'
+    params = {
+        'format': 'csljson',
+    }
+    headers = {
+        'User-Agent': get_manubot_user_agent(),
+    }
+    response = requests.post(api_url, params=params, headers=headers, json=zotero_data)
+    csl_json = response.json()
+    return csl_json
+
+if __name__ == '__main__':
+    import json
+    data = web_query('http://docs.python-requests.org/en/master/user/quickstart/')
+    print(json.dumps(data, indent=2))
+    csl_json = export_as_csl(data)
+    print(json.dumps(csl_json, indent=2))

--- a/tests/test_zotero.py
+++ b/tests/test_zotero.py
@@ -9,6 +9,15 @@ from manubot.cite.url import get_url_citeproc_zotero
 
 
 def test_web_query():
+    """
+    The translation-server web endpoint can be tested via curl:
+    ```
+    curl \
+      --header "Content-Type: text/plain" \
+      --data 'https://bigthink.com/neurobonkers/a-pirate-bay-for-science' \
+      'https://translate.manubot.org/web'
+    ```
+    """
     url = 'https://bigthink.com/neurobonkers/a-pirate-bay-for-science'
     zotero_data = web_query(url)
     assert isinstance(zotero_data, list)
@@ -17,6 +26,15 @@ def test_web_query():
 
 
 def test_export_as_csl():
+    """
+    CSL export can be tested via curl:
+    ```
+    curl \
+      --header "Content-Type: application/json" \
+      --data '[{"key": "IN22XN53", "itemType": "webpage", "date": "2016-02-09T20:12:00"}]' \
+      'https://translate.manubot.org/export?format=csljson'
+    ```
+    """
     zotero_data = [
         {
             "key": "IN22XN53",
@@ -52,6 +70,15 @@ def test_web_query_fails_with_multiple_results():
 
 
 def test_search_query():
+    """
+    The translation-server search endpoint can be tested via curl:
+    ```
+    curl \
+      --header "Content-Type: text/plain" \
+      --data 'isbn:9781339919881' \
+      'https://translate.manubot.org/search'
+    ```
+    """
     identifier = 'isbn:9781339919881'
     zotero_data = search_query(identifier)
     assert zotero_data[0]['title'].startswith('The hetnet awakens')

--- a/tests/test_zotero.py
+++ b/tests/test_zotero.py
@@ -1,0 +1,53 @@
+import pytest
+
+from manubot.cite.zotero import (
+    web_query,
+    search_query,
+    export_as_csl
+)
+from manubot.cite.url import get_url_citeproc_zotero
+
+
+def test_web_query():
+    """
+    https://bigthink.com/neurobonkers/a-pirate-bay-for-science
+    """
+    url = 'https://bigthink.com/neurobonkers/a-pirate-bay-for-science'
+    zotero_data = web_query(url)
+    assert isinstance(zotero_data, list)
+    assert len(zotero_data) == 1
+    assert zotero_data[0]['title'] == "Meet the Robin Hood of Science"
+
+
+def test_export_as_csl():
+    zotero_data = [
+        {
+            "key": "IN22XN53",
+            "version": 0,
+            "itemType": "webpage",
+            "creators": [],
+            "tags": [],
+            "title": "Meet the Robin Hood of Science",
+            "websiteTitle": "Big Think",
+            "date": "2016-02-09T20:12:00",
+            "url": "https://bigthink.com/neurobonkers/a-pirate-bay-for-science",
+            "abstractNote": "How one researcher created a pirate bay for science more powerful than even libraries at top universities.",
+            "language": "en",
+            "accessDate": "2018-12-06T20:10:14Z",
+        }
+    ]
+    csl_item = export_as_csl(zotero_data)[0]
+    assert csl_item['title'] == "Meet the Robin Hood of Science"
+    assert csl_item['container-title'] == 'Big Think'
+
+
+def test_web_query_fails_with_multiple_results():
+    url = 'https://www.ncbi.nlm.nih.gov/pubmed/?term=sci-hub%5Btitle%5D'
+    with pytest.raises(ValueError, match='multiple results'):
+        web_query(url)
+
+
+def test_search_query():
+    identifier = 'isbn:9781339919881'
+    zotero_data = search_query(identifier)
+    assert zotero_data[0]['title'].startswith('The hetnet awakens')

--- a/tests/test_zotero.py
+++ b/tests/test_zotero.py
@@ -9,9 +9,6 @@ from manubot.cite.url import get_url_citeproc_zotero
 
 
 def test_web_query():
-    """
-    https://bigthink.com/neurobonkers/a-pirate-bay-for-science
-    """
     url = 'https://bigthink.com/neurobonkers/a-pirate-bay-for-science'
     zotero_data = web_query(url)
     assert isinstance(zotero_data, list)
@@ -39,6 +36,13 @@ def test_export_as_csl():
     csl_item = export_as_csl(zotero_data)[0]
     assert csl_item['title'] == "Meet the Robin Hood of Science"
     assert csl_item['container-title'] == 'Big Think'
+
+
+def test_get_url_citeproc_zotero():
+    url = 'https://nyti.ms/1NuB0WJ'
+    csl_item = get_url_citeproc_zotero(url)
+    assert csl_item['title'] == 'Unraveling the Ties of Altitude, Oxygen and Lung Cancer'
+    assert csl_item['author'][0]['family'] == 'Johnson'
 
 
 def test_web_query_fails_with_multiple_results():


### PR DESCRIPTION
Use manubot's translation server to retrieve metadata for URLs and ISBNs. Switch URLs and ISBNs to use fallback methods if translation-server fails.

Closes #70.