### PR TITLE
Allow null authors in metadata.yaml

### DIFF
--- a/manubot/process/util.py
+++ b/manubot/process/util.py
@@ -196,6 +196,8 @@ def get_metadata_and_variables(args):
 
     # Process authors metadata
     authors = metadata.pop('author_info', [])
+    if authors is None:
+        authors = []
     metadata['author-meta'] = [author['name'] for author in authors]
     variables['authors'] = authors
     variables = add_author_affiliations(variables)


### PR DESCRIPTION
Previousely, the following metadata.yaml would cause the following exception:

```yaml
title: "Title"
lang: en-US
author_info:
```

```python-traceback
  File "manubot/process/util.py", line 199, in get_metadata_and_variables
    metadata['author-meta'] = [author['name'] for author in authors]
TypeError: 'NoneType' object is not iterable
```

Instead, we should treat null authors field as an empty array/list.